### PR TITLE
Try to find the gmt executable

### DIFF
--- a/create_omtb_garmin_img.sh
+++ b/create_omtb_garmin_img.sh
@@ -43,7 +43,7 @@ usage()
 zparseopts -A ARGS_A -D -E -- "m:" "o:"
 OMTB_EXE="$1"
 TYPFILE="$2"
-GMT_CMD==gmt
+GMT_CMD="$(which gmt)"
 MKGMAP=( ${ARGS_A[-m]}(.N,@-.) /usr/share/mkgmap/mkgmap.jar(.N,@-.) /usr/local/share/mkgmap/mkgmap.jar(.N,@-.) /usr/share/java/mkgmap.jar (.N,@-.) ${^path}/mkgmap.jar(.N,@-.) )
 MKGMAP="${MKGMAP[1]}"
 


### PR DESCRIPTION
I'm not sure what the line
```zsh
GMT_CMD==gmt
```
is supposed to do? If this was a typo (`GMT_CMD=gmt`), it still does not work for me, because the following conditional
```zsh
if ! [[ -x $GMT_CMD ]] ; then
```
will not find the gmt executable. The version with `$(which gmt)` works for me, but it might well be that I'm missing something.

In any case, thanks a lot for the script!