### PR TITLE
Various fixes and improvements

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -55,6 +55,8 @@ also, get newest mkgmap from http://www.mkgmap.org.uk/snapshots/ and install (ak
        velw: Wide layout optimized for high DPI screens like Oregon
        race: Clean layout for road biking. No buildings or features.
      or give the path to your own .TYP style file
+
   Options:
+     -g <path/to/gmt>
      -m <path/to/mkgmap.jar>
      -o <path/to/outputdir>

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -55,7 +55,6 @@ also, get newest mkgmap from http://www.mkgmap.org.uk/snapshots/ and install (ak
        velw: Wide layout optimized for high DPI screens like Oregon
        race: Clean layout for road biking. No buildings or features.
      or give the path to your own .TYP style file
-
   Options:
      -g <path/to/gmt>
      -m <path/to/mkgmap.jar>

--- a/create_omtb_garmin_img.sh
+++ b/create_omtb_garmin_img.sh
@@ -51,11 +51,16 @@ GMT_CMD="${GMT_CMD[1]}"
 MKGMAP=( ${ARGS_A[-m]}(.N,@-.) /usr/share/mkgmap/mkgmap.jar(.N,@-.) /usr/local/share/mkgmap/mkgmap.jar(.N,@-.) /usr/share/java/mkgmap.jar (.N,@-.) ${^path}/mkgmap.jar(.N,@-.) )
 MKGMAP="${MKGMAP[1]}"
 
-if ! [[ -x $GMT_CMD ]] ; then
+if ! [[ -x "$GMT_CMD" ]] ; then
     if ! [[ -x =wine ]] ; then
         print "ERROR: You need to either install wine or the gmt Linux binary !" > /dev/stderr
         exit 3    
+    elif ! [[ -f gmt.exe ]]; then
+        print "ERROR: gmt.exe for usage with wine not found. Please place it in the" > /dev/stderr
+        print "current directory." > /dev/stderr
+        exit 3
     fi
+
     # use supplied gmt.exe with wine
     GMT_CMD="wine ./gmt.exe"
 fi

--- a/create_omtb_garmin_img.sh
+++ b/create_omtb_garmin_img.sh
@@ -61,7 +61,7 @@ fi
 GMT_CMD=( ${ARGS_A[-g]}(.N,@-.) ${^path}/gmt(.N,@-.) )
 GMT_CMD="${GMT_CMD[1]}"
 
-MKGMAP=( ${ARGS_A[-m]}(.N,@-.) /usr/share/mkgmap/mkgmap.jar(.N,@-.) /usr/local/share/mkgmap/mkgmap.jar(.N,@-.) /usr/share/java/mkgmap.jar (.N,@-.) ${^path}/mkgmap.jar(.N,@-.) )
+MKGMAP=( ${ARGS_A[-m]}(.N,@-.) /usr/share/mkgmap/mkgmap.jar(.N,@-.) /usr/local/share/mkgmap/mkgmap.jar(.N,@-.) /usr/share/java/mkgmap.jar(.N,@-.) ${^path}/mkgmap.jar(.N,@-.) )
 MKGMAP="${MKGMAP[1]}"
 
 if ! [[ -x "$GMT_CMD" ]] ; then

--- a/create_omtb_garmin_img.sh
+++ b/create_omtb_garmin_img.sh
@@ -61,7 +61,7 @@ fi
 GMT_CMD=( ${ARGS_A[-g]}(.N,@-.) ${^path}/gmt(.N,@-.) )
 GMT_CMD="${GMT_CMD[1]}"
 
-MKGMAP=( ${ARGS_A[-m]}(.N,@-.) /usr/share/mkgmap/mkgmap.jar(.N,@-.) /usr/local/share/mkgmap/mkgmap.jar(.N,@-.) /usr/share/java/mkgmap.jar(.N,@-.) ${^path}/mkgmap.jar(.N,@-.) )
+MKGMAP=( ${ARGS_A[-m]}(.N,@-.) /usr/share/mkgmap/mkgmap.jar(.N,@-.) /usr/local/share/mkgmap/mkgmap.jar(.N,@-.) /usr/share/java/mkgmap.jar(.N,@-.) /usr/share/java/mkgmap/mkgmap.jar(.N,@-.) ${^path}/mkgmap.jar(.N,@-.) )
 MKGMAP="${MKGMAP[1]}"
 
 if ! [[ -x "$GMT_CMD" ]] ; then

--- a/create_omtb_garmin_img.sh
+++ b/create_omtb_garmin_img.sh
@@ -34,16 +34,20 @@ usage()
     fi
     print "   or give the path to your own .TYP style file" > /dev/stderr
     print "\nOptions:" > /dev/stderr
+    print "   -g <path/to/gmt>" > /dev/stderr
     print "   -m <path/to/mkgmap.jar>" > /dev/stderr
     print "   -o <path/to/outputdir>\n" > /dev/stderr
     exit 1
     # descriptions taken from openmtbmap.org  batch files
 }
 
-zparseopts -A ARGS_A -D -E -- "m:" "o:"
+zparseopts -A ARGS_A -D -E -- "g:" "m:" "o:"
 OMTB_EXE="$1"
 TYPFILE="$2"
-GMT_CMD==gmt
+
+GMT_CMD=( ${ARGS_A[-g]}(.N,@-.) ${^path}/gmt(.N,@-.) )
+GMT_CMD="${GMT_CMD[1]}"
+
 MKGMAP=( ${ARGS_A[-m]}(.N,@-.) /usr/share/mkgmap/mkgmap.jar(.N,@-.) /usr/local/share/mkgmap/mkgmap.jar(.N,@-.) /usr/share/java/mkgmap.jar (.N,@-.) ${^path}/mkgmap.jar(.N,@-.) )
 MKGMAP="${MKGMAP[1]}"
 

--- a/create_omtb_garmin_img.sh
+++ b/create_omtb_garmin_img.sh
@@ -45,7 +45,12 @@ zparseopts -A ARGS_A -D -E -- "g:" "m:" "o:"
 OMTB_EXE="$1"
 TYPFILE="$2"
 
-[[ -z $TYPFILE || ! -f $OMTB_EXE ]] && usage
+if [ $# -lt 2 ]; then
+    usage
+elif [ ! -f "$OMTB_EXE" ]; then
+    echo "ERROR: Input map file does not exist (or is not a file)!" > /dev/stderr
+    exit 2
+fi
 
 if [[ ${OMTB_EXE:t} == mtb* ]]; then
     OMTBORVELO=openmtbmap

--- a/create_omtb_garmin_img.sh
+++ b/create_omtb_garmin_img.sh
@@ -45,6 +45,19 @@ zparseopts -A ARGS_A -D -E -- "g:" "m:" "o:"
 OMTB_EXE="$1"
 TYPFILE="$2"
 
+[[ -z $TYPFILE || ! -f $OMTB_EXE ]] && usage
+
+if [[ ${OMTB_EXE:t} == mtb* ]]; then
+    OMTBORVELO=openmtbmap
+    OMTB_NAME="${OMTB_EXE:t:r:s/mtb/}"
+elif [[ ${OMTB_EXE:t} == velo* ]]; then
+    OMTBORVELO=openvelomap
+    OMTB_NAME="${OMTB_EXE:t:r:s/velo/}"
+elif [[ -n ${OMTB_EXE:t} ]]; then
+    print "\nERROR: Not a openmtbmap.org or openvelomap.org file ?" > /dev/stderr
+    usage
+fi
+
 GMT_CMD=( ${ARGS_A[-g]}(.N,@-.) ${^path}/gmt(.N,@-.) )
 GMT_CMD="${GMT_CMD[1]}"
 
@@ -69,19 +82,6 @@ if ! [[ -x =7z ]]; then
     print "\nERROR: 7z is not installed, but needed to extract openmtbmap downloads !" > /dev/stderr
     exit 3
 fi
-
-if [[ ${OMTB_EXE:t} == mtb* ]]; then
-    OMTBORVELO=openmtbmap
-    OMTB_NAME="${OMTB_EXE:t:r:s/mtb/}"
-elif [[ ${OMTB_EXE:t} == velo* ]]; then
-    OMTBORVELO=openvelomap
-    OMTB_NAME="${OMTB_EXE:t:r:s/velo/}"
-elif [[ -n ${OMTB_EXE:t} ]]; then
-    print "\nERROR: Not a openmtbmap.org or openvelomap.org file ?" > /dev/stderr
-    usage
-fi
-
-[[ -z $TYPFILE || ! -f $OMTB_EXE ]] && usage
 
 DESC="${OMTBORVELO}_${OMTB_NAME}"
 if [[ -d ${ARGS_A[-o]} ]]; then

--- a/create_omtb_garmin_img.sh
+++ b/create_omtb_garmin_img.sh
@@ -69,8 +69,7 @@ if ! [[ -x "$GMT_CMD" ]] ; then
         print "ERROR: You need to either install wine or the gmt Linux binary !" > /dev/stderr
         exit 3    
     elif ! [[ -f gmt.exe ]]; then
-        print "ERROR: gmt.exe for usage with wine not found. Please place it in the" > /dev/stderr
-        print "current directory." > /dev/stderr
+        print "ERROR: gmt.exe for usage with wine not found. Please place it in the current directory." > /dev/stderr
         exit 3
     fi
 

--- a/create_omtb_garmin_img.sh
+++ b/create_omtb_garmin_img.sh
@@ -158,7 +158,7 @@ cp $TYPFILE 01002468.TYP || exit 4
 FID=${${FIMG_a:t}[1][1,4]}
 print "Using FID $FID"
 
-$GMT_CMD -wy $FID 01002468.TYP
+${=GMT_CMD} -wy $FID 01002468.TYP
 if [[ -n $MKGMAP ]]; then
     print "Using mkgmap, building address search index..."
     #java -Xmx1000M -jar mkgmap.jar --family-id=$FID --index --description="$DESC" --series-name="$DESC" --family-name="$DESC" --show-profiles=1  --product-id=1 --gmapsupp 6*.img 7*.img 01002468.TYP
@@ -166,7 +166,7 @@ if [[ -n $MKGMAP ]]; then
     mv (#i)gmapsupp.img "${DSTFILENAME}" || exit 7
 else
     print "mkgmap not found, using gmt..."
-    $GMT_CMD -j -o "${DSTFILENAME}" -f $FID -m "$DESC" 6*.img 7*.img 01002468.TYP || exit 7
+    ${=GMT_CMD} -j -o "${DSTFILENAME}" -f $FID -m "$DESC" 6*.img 7*.img 01002468.TYP || exit 7
 fi
 rm -R "$TMPDIR"
 print "\nSuccessfully created ${DSTFILENAME}"

--- a/create_omtb_garmin_img.sh
+++ b/create_omtb_garmin_img.sh
@@ -64,10 +64,10 @@ elif [[ -n ${OMTB_EXE:t} ]]; then
 fi
 
 GMT_CMD=( ${ARGS_A[-g]}(.N,@-.) ${^path}/gmt(.N,@-.) )
-GMT_CMD="${GMT_CMD[1]}"
+GMT_CMD="${GMT_CMD[1]:a}"
 
 MKGMAP=( ${ARGS_A[-m]}(.N,@-.) /usr/share/mkgmap/mkgmap.jar(.N,@-.) /usr/local/share/mkgmap/mkgmap.jar(.N,@-.) /usr/share/java/mkgmap.jar(.N,@-.) /usr/share/java/mkgmap/mkgmap.jar(.N,@-.) ${^path}/mkgmap.jar(.N,@-.) )
-MKGMAP="${MKGMAP[1]}"
+MKGMAP="${MKGMAP[1]:a}"
 
 if ! [[ -x "$GMT_CMD" ]] ; then
     if ! [[ -x =wine ]] ; then
@@ -79,7 +79,7 @@ if ! [[ -x "$GMT_CMD" ]] ; then
     fi
 
     # use supplied gmt.exe with wine
-    GMT_CMD="wine ./gmt.exe"
+    GMT_CMD="wine ${PWD}/gmt.exe"
 fi
 
 if ! [[ -x =7z ]]; then


### PR DESCRIPTION
Apologies for this rather unspecific pull request -- it contains the following improvements:

- It is now possible to specify the path to the gmaptool using the `-g` option (just like the `-m` option for `mkgmap`). If no explicit path is given, then `PATH` is searched for the `gmt` binary.
- If no native `gmt` binary could be found and the script decides to use the Windows binary using `wine`, it didn't check if the Windows binary actually exists. Now it does.
- `/usr/share/java/mkgmap.jar` was always included in the `mkgmap` location search list because of a space character between the path and the glob qualifier. That lead to the script not noticing that `mkgmap` was missing on certain setups; now, that path is only included if it exists.
- I added `/usr/share/java/mkgmap/mkgmap.jar` to the `mkgmap` location search list since that's where `mkgmap` is installed under Arch Linux.
- The script now can handle relative paths with `-g` and `-m` (by making them absolute if they are not already). Since the script changes its working directory to the temporary directory, relative paths to `gmt` and `mkgmap` may be inaccessible from that directory.
- I made the script display an explicit error message if the input map file does not exist. Previously, it just showed the usage text and exited, which I found confusing.
- The script's usage text is now displayed *before* the existence of requisites (like `7z` and `gmt`) is checked, so that the user can read it without having to install the required utilities.