### PR TITLE
Add Singularity build file

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -38,6 +38,17 @@ also, get newest mkgmap from http://www.mkgmap.org.uk/snapshots/ and install (ak
   zypper ar http://download.opensuse.org/repositories/Application:/Geo/openSUSE_13.1/ GEO
   zypper ref
   zypper in p7zip mkgmap GMT
+  
+==== Installation with Singularity ====
+
+Alternatively, you can build a Singularity container with all the dependencies:
+
+  singularity build --fakeroot create_omtb_garmin_img.sif Singularity
+
+To execute the script from within the container:
+   
+  singularity run create_omtb_garmin_img.sif \
+       create_omtb_garmin_img.sh [options] <mtb*.exe|velo*.exe> <TYP-file or TYP-style>
 
 === Usage ===
 

--- a/Singularity
+++ b/Singularity
@@ -1,0 +1,13 @@
+BootStrap: library
+From: ubuntu:16.04
+
+%files
+    create_omtb_garmin_img.sh /usr/local/bin/create_omtb_garmin_img.sh 
+
+%post
+    apt-get update
+    apt-get install -y zsh p7zip-full mkgmap wget unzip
+    wget http://www.gmaptool.eu/sites/default/files/lgmt08220.zip
+    unzip lgmt08220.zip gmt
+    mv gmt /usr/local/bin/
+


### PR DESCRIPTION
I created a singularity container containing everything required to run the script. Maybe it's useful for others. 

It would even be possible to attach the container SIF-file as an asset to a github release, that way users would save the `singularity build` step. 